### PR TITLE
Allow max speaking time to be configured from command line

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,10 @@ This is terrible, don't use it
   `slacksay TOKEN`
   TOKEN can be obtained from https://api.slack.com/web
 
+  `slacksay TOKEN -t 4`
+  Sets the max time a single message will speak. Default: 6 seconds
+
+
 ##TODO
  * [ ] make electron app
  * [ ] make cross-platform (currently mac only)

--- a/bot.js
+++ b/bot.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 var token = process.argv[2];
+var maxSpeakingTimeInSeconds = 6;
 var Botkit = require('botkit');
 var controller = Botkit.slackbot();
 var bot = controller.spawn({ token })
@@ -13,6 +14,10 @@ if (!token) {
     usage: slacksay TOKEN
   `)
   return 1;
+}
+
+if(process.argv.indexOf("-t") != -1){
+    maxSpeakingTimeInSeconds = process.argv[process.argv.indexOf("-t") + 1];
 }
 
 bot.startRTM(function(err) {
@@ -52,7 +57,7 @@ controller.hears(".*", ["direct_message","direct_mention","mention","ambient"], 
 
       const commands = [
         quote(['say', '--output-file', 'out.aiff', '--voice', 'Daniel', text]),
-        'afplay --volume .7 --rate 1.2 --time 6 out.aiff',
+        `afplay --volume .7 --rate 1.2 --time ${maxSpeakingTimeInSeconds} out.aiff`,
         'rm out.aiff'
       ]
 


### PR DESCRIPTION
When 6 seconds just isn't enough
